### PR TITLE
Create failsafe for distros without bash

### DIFF
--- a/linux/exec.sh
+++ b/linux/exec.sh
@@ -3,7 +3,7 @@
 source .env
 
 if [ "$1" == "" ]; then
-	CMD=bash
+	CMD="if [ -e /bin/bash ]; then /bin/bash; else /bin/sh; fi"
 else
 	CMD=$@
 fi


### PR DESCRIPTION
`bash` doesn't exist in images like `alpine`, this makes it so that it checks for the existence of `/bin/bash` first and executes it if it's there, if not it falls back on `/bin/sh`.